### PR TITLE
Gutter line number colors #7647

### DIFF
--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -66,12 +66,32 @@ html[dir="rtl"] .editor-mount {
   --breakpoint-stroke-disabled: var(--blue-60);
 }
 
-.theme-light .cm-s-mozilla .empty-line .CodeMirror-linenumber {
+.theme-light .cm-s-mozilla .CodeMirror-linenumber {
   color: var(--grey-40);
 }
 
-.theme-dark .cm-s-mozilla .empty-line .CodeMirror-linenumber {
+.theme-dark .cm-s-mozilla {
   color: var(--grey-60);
+}
+
+/* dark theme line number and empty line number */
+.theme-dark {
+  .CodeMirror-linenumber {
+    color: var(--grey-40);
+  }
+  .empty-line{
+    color: var(--grey-50);
+  }
+}
+
+/* dark theme line number and empty line number */
+.theme-light {
+  .CodeMirror-linenumber {
+    color: var(--grey-50);
+  }
+  .empty-line{
+    color: var(--grey-40);
+  }
 }
 
 :not(.empty-line):not(.new-breakpoint)


### PR DESCRIPTION
changed line number and empty line number to -
Dark Mode
Line number: Grey 40 #b1b1b3
Empty line number: Grey 50 #737373

Light Mode
Line number: Grey 50 #737373
Empty line number: Grey 40 #b1b1b3

Fixes #<issue number>

Here's the Pull Request Doc
https://firefox-dev.tools/debugger.html/docs/pull-requests.html

### Summary of Changes

* change 1
* change 2

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] Command-P opens the panel
- [x] Clicking “+” opens the panel
- [x] Clicking a source navigates to the source
- [x] Clicking "x" closes the panel

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots/Videos (OPTIONAL)
